### PR TITLE
Award points after a month automatically if event is not marked

### DIFF
--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -178,6 +178,13 @@ class DatabaseService {
       deleteEvent(event.eventID);
       event.attendees.forEach((attendee) async {
         UserData user = await getUserData(attendee);
+        if (!event.eventMarked) {
+          addPointsToUser(user.uid, 50);
+          if (user.uid == event.attendees[0]) {
+            // award double points if user is initiator
+            addPointsToUser(user.uid, 50);
+          }
+        }
         user.events.removeWhere((eventID) => eventID == event.eventID);
         updateUserDataWithID(
             user.uid,


### PR DESCRIPTION
Before our garbage collection system deletes the event. The system checks if attendance is taken already and automatically takes attendance if it has not already been done so. It will assume everyone is present and award 100 xp to the initiator and 50 xp to everyone else